### PR TITLE
Custom URL for NavigateCU

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+navigatecu.com


### PR DESCRIPTION
NavigateCU now lives at www.navigatecu.com
